### PR TITLE
Use sismember

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rcurtain (0.0.4)
+    rcurtain (0.0.6)
       hiredis
       redis (~> 3.2)
 
@@ -10,7 +10,7 @@ GEM
   specs:
     diff-lcs (1.2.5)
     hiredis (0.6.1)
-    redis (3.3.3)
+    redis (3.3.5)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -33,4 +33,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.12.3
+   1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
+    fakeredis (0.7.0)
+      redis (>= 3.2, < 5.0)
     hiredis (0.6.1)
     redis (3.3.5)
     rspec (3.4.0)
@@ -29,6 +31,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  fakeredis
   rcurtain!
   rspec
 

--- a/lib/rcurtain/curtain.rb
+++ b/lib/rcurtain/curtain.rb
@@ -11,8 +11,7 @@ module Rcurtain
     end
 
     def opened?(feature, users = [])
-      return users_enabled?(feature, users) unless invalid_users?(users)
-      compare_percentage?(percentage(feature))
+      compare_percentage?(percentage(feature)) || users_enabled?(feature, users)
     rescue Redis::CannotConnectError
       return Rcurtain.configuration.default_response
     end
@@ -33,6 +32,7 @@ module Rcurtain
       end
 
       def users_enabled?(feature_name, users = [])
+        return false if invalid_users?(users)
         users.all? { |user| redis.sismember(feature_name, user) }
       end
 

--- a/lib/rcurtain/curtain.rb
+++ b/lib/rcurtain/curtain.rb
@@ -33,7 +33,7 @@ module Rcurtain
 
       def users_enabled?(feature_name, users = [])
         return false if invalid_users?(users)
-        users.all? { |user| redis.sismember(feature_name, user) }
+        users.all? { |user| redis.sismember("feature:#{feature_name}:users", user) }
       end
 
       def invalid_users?(users)

--- a/lib/rcurtain/curtain.rb
+++ b/lib/rcurtain/curtain.rb
@@ -11,10 +11,8 @@ module Rcurtain
     end
 
     def opened?(feature, users = [])
-      feature_percentage = percentage(feature)
-      return (compare_percentage?(feature_percentage)) || users_enabled?(feature, users) unless users.empty?
-
-      compare_percentage?(feature_percentage)
+      return users_enabled?(feature, users) unless invalid_users?(users)
+      compare_percentage?(percentage(feature))
     rescue Redis::CannotConnectError
       return Rcurtain.configuration.default_response
     end
@@ -47,5 +45,8 @@ module Rcurtain
         rnd.rand(1..100) <= percentage.to_f
       end
 
+      def invalid_users?(users)
+        users.nil? || users.empty?
+      end
   end
 end

--- a/lib/rcurtain/curtain.rb
+++ b/lib/rcurtain/curtain.rb
@@ -36,6 +36,10 @@ module Rcurtain
         users.all? { |user| redis.sismember(feature_name, user) }
       end
 
+      def invalid_users?(users)
+        users.nil? || users.empty?
+      end
+
       def percentage(feature_name)
         redis.get("feature:#{feature_name}:percentage") || 0
       end
@@ -43,10 +47,6 @@ module Rcurtain
       def compare_percentage? (percentage)
         rnd = Random.new
         rnd.rand(1..100) <= percentage.to_f
-      end
-
-      def invalid_users?(users)
-        users.nil? || users.empty?
       end
   end
 end

--- a/lib/rcurtain/curtain.rb
+++ b/lib/rcurtain/curtain.rb
@@ -10,10 +10,11 @@ module Rcurtain
       @redis = Redis.new(:url => Rcurtain.configuration.url)
     end
 
-    def opened? (feature, users = [])
-      feature_percentage = compare_percentage?(percentage(feature))
-      return feature_percentage || users_enabled?(feature, users) unless users.empty?
-      feature_percentage
+    def opened?(feature, users = [])
+      feature_percentage = percentage(feature)
+      return (compare_percentage?(feature_percentage)) || users_enabled?(feature, users) unless users.empty?
+
+      compare_percentage?(feature_percentage)
     rescue Redis::CannotConnectError
       return Rcurtain.configuration.default_response
     end
@@ -38,7 +39,7 @@ module Rcurtain
       end
 
       def percentage(feature_name)
-        redis.get("feature:#{name}:percentage") || 0
+        redis.get("feature:#{feature_name}:percentage") || 0
       end
 
       def compare_percentage? (percentage)

--- a/rcurtain.gemspec
+++ b/rcurtain.gemspec
@@ -15,5 +15,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "hiredis"
   s.add_runtime_dependency "redis", "~>3.2"
+  s.add_development_dependency 'fakeredis'
   s.add_development_dependency "rspec"
 end

--- a/spec/lib/curtain_spec.rb
+++ b/spec/lib/curtain_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require 'fakeredis/rspec'
 
 describe Rcurtain do
 
@@ -15,7 +16,7 @@ describe Rcurtain do
     context "when 100%" do
       before do
         allow_any_instance_of(Redis).to receive(:get).and_return(100)
-        allow_any_instance_of(Redis).to receive(:smembers).and_return(nil)
+        allow_any_instance_of(Redis).to receive(:sismember).and_return(false)
       end
 
       it { expect(rcurtain.opened? "feature").to be true }
@@ -24,7 +25,7 @@ describe Rcurtain do
     context "when user exists" do
       before do
         allow_any_instance_of(Redis).to receive(:get).and_return(0)
-        allow_any_instance_of(Redis).to receive(:smembers).and_return(['MPA-123'])
+        allow_any_instance_of(Redis).to receive(:sismember).and_return(true)
       end
 
       it { expect(rcurtain.opened?("feature", ['MPA-123'])).to be true }


### PR DESCRIPTION
This PR changes the way that rcurtain searches for members. Instead of retrieving a list of members (According to Redis' docs, runs in O(N)), we simply retrieve if the user is in that feature or not (O(1), according to Redis' doc).

This is useful because `smembers` **locks** (https://redis.io/commands/scan -> 

```
KEYS or SMEMBERS that may block the server for a long time (even several seconds) 
when called against big collections of keys or elements.
```
), while `sismember` shouldn't.