### PR TITLE
Add sample logic to users from a feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.0.1)
     diff-lcs (1.2.5)
     fakeredis (0.7.0)
       redis (>= 3.2, < 5.0)
     hiredis (0.6.1)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     redis (3.3.5)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rcurtain (0.0.6)
+    rcurtain (0.0.7)
       hiredis
       redis (~> 3.2)
 
@@ -9,10 +9,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     byebug (11.0.1)
+    coderay (1.1.2)
     diff-lcs (1.2.5)
     fakeredis (0.7.0)
       redis (>= 3.2, < 5.0)
-    hiredis (0.6.1)
+    hiredis (0.6.3)
+    method_source (0.9.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -39,8 +41,9 @@ PLATFORMS
 
 DEPENDENCIES
   fakeredis
+  pry-byebug
   rcurtain!
   rspec
 
 BUNDLED WITH
-   1.16.0
+   1.16.2

--- a/lib/rcurtain/curtain.rb
+++ b/lib/rcurtain/curtain.rb
@@ -1,4 +1,6 @@
-require "singleton"
+# frozen_string_literal: true
+
+require 'singleton'
 
 module Rcurtain
   class Curtain
@@ -7,46 +9,55 @@ module Rcurtain
     attr_reader :redis
 
     def initialize
-      @redis = Redis.new(:url => Rcurtain.configuration.url)
+      @redis = Redis.new(url: Rcurtain.configuration.url)
     end
 
     def opened?(feature, users = [])
       compare_percentage?(percentage(feature)) || users_enabled?(feature, users)
     rescue Redis::CannotConnectError
-      return Rcurtain.configuration.default_response
+      Rcurtain.configuration.default_response
     end
 
     def get_users(feature)
       get_feature(feature).users
     rescue Redis::CannotConnectError
-        Rcurtain.configuration.default_response
+      Rcurtain.configuration.default_response
+    end
     end
 
     private
-      def get_feature (name)
-        percentage = redis.get("feature:#{name}:percentage") || 0
 
-        users = redis.smembers("feature:#{name}:users") || []
+    def get_feature(name)
+      percentage = redis.get("feature:#{name}:percentage") || 0
 
-        return Feature.new(name, percentage, users)
-      end
+      users = redis.smembers("feature:#{name}:users") || []
 
-      def users_enabled?(feature_name, users = [])
-        return false if invalid_users?(users)
-        users.all? { |user| redis.sismember("feature:#{feature_name}:users", user) }
-      end
+      Feature.new(name, percentage, users)
+    end
 
-      def invalid_users?(users)
-        users.nil? || users.empty?
-      end
 
-      def percentage(feature_name)
-        redis.get("feature:#{feature_name}:percentage") || 0
-      end
+      Feature.new(name, percentage, users)
+    end
 
-      def compare_percentage? (percentage)
-        rnd = Random.new
-        rnd.rand(1..100) <= percentage.to_f
-      end
+    def invalid_users?(users)
+      users.nil? || users.empty?
+    end
+
+    def percentage(feature_name)
+      redis.get("feature:#{feature_name}:percentage") || 0
+    end
+
+    def compare_percentage?(percentage)
+      rnd = Random.new
+      rnd.rand(1..100) <= percentage.to_f
+    end
+
+    def sample_ttl(days = nil)
+      one_day_in_seconds * (days || 1)
+    end
+
+    def one_day_in_seconds
+      24 * 60 * 60
+    end
   end
 end

--- a/lib/rcurtain/curtain.rb
+++ b/lib/rcurtain/curtain.rb
@@ -31,12 +31,12 @@ module Rcurtain
 
       users = get_feature(feature).users
       percentage = get_feature_sample_percentage(feature)
-      ttl = get_feature_sample_ttl(feature)&.to_i
+      ttl_in_days = get_feature_sample_ttl(feature)&.to_i
 
       sample_number = users.size * (percentage.to_f / 100)
       users_sample = users.sample(sample_number.to_i)
 
-      persist_users_sample(feature, users_sample, ttl)
+      persist_users_sample(feature, users_sample, ttl_in_days)
 
       users_sample
     rescue Redis::CannotConnectError

--- a/lib/rcurtain/feature.rb
+++ b/lib/rcurtain/feature.rb
@@ -1,13 +1,11 @@
 module Rcurtain
   class Feature
-
     attr_accessor :name, :percentage, :users
 
-    def initialize (name, percentage, users)
+    def initialize(name, percentage, users)
       @name = name
       @percentage = percentage
       @users = users
     end
-
   end
 end

--- a/rcurtain.gemspec
+++ b/rcurtain.gemspec
@@ -6,9 +6,8 @@ Gem::Specification.new do |s|
   s.description = "Open the curtain and see if your feature is enabled"
   s.authors     = ["Danillo Souza", "Gabriel Queiroz", "Guilherme Sipoloni"]
   s.email       = ["danillo.souza@moip.com.br", "gabriel.queiroz@moip.com.br", "guilehrme.sipoloni@moip.com.br"]
-  s.homepage    =
-    'http://github.com/moip/rcurtain'
-  s.license       = 'MIT'
+  s.homepage    = 'http://github.com/moip/rcurtain'
+  s.license     = 'MIT'
 
   s.files       = Dir['**/*'].keep_if { |file| File.file?(file) }
   s.require_paths = ['lib']

--- a/rcurtain.gemspec
+++ b/rcurtain.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "redis", "~>3.2"
   s.add_development_dependency 'fakeredis'
   s.add_development_dependency "rspec"
+  s.add_development_dependency "pry-byebug"
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,10 +1,10 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Rcurtain do
-
-  describe "#configure" do
-
-    context "configure url for redis" do
+  describe '#configure' do
+    context 'configure url for redis' do
       before do
         Rcurtain.configure do |config|
           config.url = 'redis://:p4ssw0rd@10.0.1.1:6380/15'
@@ -13,11 +13,10 @@ describe Rcurtain do
 
       subject(:rcurtain) { Rcurtain.configuration }
 
-      it {expect(subject.url).to eq('redis://:p4ssw0rd@10.0.1.1:6380/15')}
-
+      it { expect(subject.url).to eq('redis://:p4ssw0rd@10.0.1.1:6380/15') }
     end
 
-    context "configure default response" do
+    context 'configure default response' do
       before do
         Rcurtain.configure do |config|
           config.default_response = true
@@ -26,9 +25,7 @@ describe Rcurtain do
 
       subject(:rcurtain) { Rcurtain.configuration }
 
-      it {expect(subject.default_response).to eq true}
+      it { expect(subject.default_response).to eq true }
     end
-
   end
-
 end

--- a/spec/lib/curtain_spec.rb
+++ b/spec/lib/curtain_spec.rb
@@ -78,4 +78,16 @@ describe Rcurtain do
 
     it { expect(rcurtain.get_users('feature')).to eq %w[123 321] }
   end
+
+  context 'get users sample from feature' do
+    before do
+      allow_any_instance_of(Redis).to receive(:get).with("feature:feature:percentage").and_return(0)
+      allow_any_instance_of(Redis).to receive(:get).with("feature:feature:users:percentage").and_return(50)
+      allow_any_instance_of(Redis).to receive(:smembers).with("feature:feature:users:sample").and_return(nil)
+      allow_any_instance_of(Redis).to receive(:smembers).with("feature:feature:users").and_return(%w[123 321])
+      allow_any_instance_of(Redis).to receive(:setex).and_return(nil)
+    end
+
+    it { expect(rcurtain.get_users_sample('feature').size).to eq 1 }
+  end
 end

--- a/spec/lib/curtain_spec.rb
+++ b/spec/lib/curtain_spec.rb
@@ -75,7 +75,7 @@ describe Rcurtain do
       allow_any_instance_of(Redis).to receive(:get).and_return(0)
       allow_any_instance_of(Redis).to receive(:smembers).and_return(['123', '321'])
     end
-    it { expect(rcurtain.get_users("feature")).to eq ['123', '321']}
-  end
 
+    it { expect(rcurtain.get_users("feature")).to eq ['123', '321'] }
+  end
 end

--- a/spec/lib/curtain_spec.rb
+++ b/spec/lib/curtain_spec.rb
@@ -82,8 +82,9 @@ describe Rcurtain do
   context 'get users sample from feature' do
     before do
       allow_any_instance_of(Redis).to receive(:get).with("feature:feature:percentage").and_return(0)
-      allow_any_instance_of(Redis).to receive(:get).with("feature:feature:users:percentage").and_return(50)
-      allow_any_instance_of(Redis).to receive(:smembers).with("feature:feature:users:sample").and_return(nil)
+      allow_any_instance_of(Redis).to receive(:get).with("feature:feature:users:session:percentage").and_return(50)
+      allow_any_instance_of(Redis).to receive(:get).with("feature:feature:users:session:ttl_in_days").and_return(1)
+      allow_any_instance_of(Redis).to receive(:smembers).with("feature:feature:users:session:sample").and_return(nil)
       allow_any_instance_of(Redis).to receive(:smembers).with("feature:feature:users").and_return(%w[123 321])
       allow_any_instance_of(Redis).to receive(:setex).and_return(nil)
     end

--- a/spec/lib/curtain_spec.rb
+++ b/spec/lib/curtain_spec.rb
@@ -1,8 +1,9 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 require 'fakeredis/rspec'
 
 describe Rcurtain do
-
   before do
     Rcurtain.configure do |config|
       config.url = 'redis://:p4ssw0rd@10.0.1.1:6380/15'
@@ -11,71 +12,70 @@ describe Rcurtain do
 
   subject(:rcurtain) { Rcurtain.instance }
 
-  context "is opened" do
-
-    context "when 100%" do
+  context 'is opened' do
+    context 'when 100%' do
       before do
         allow_any_instance_of(Redis).to receive(:get).and_return(100)
         allow_any_instance_of(Redis).to receive(:sismember).and_return(false)
       end
 
-      it { expect(rcurtain.opened? "feature").to be true }
+      it { expect(rcurtain.opened?('feature')).to be true }
     end
 
-    context "when user exists" do
+    context 'when user exists' do
       before do
         allow_any_instance_of(Redis).to receive(:get).and_return(0)
         allow_any_instance_of(Redis).to receive(:sismember).and_return(true)
       end
 
-      it { expect(rcurtain.opened?("feature", ['MPA-123'])).to be true }
+      it { expect(rcurtain.opened?('feature', ['MPA-123'])).to be true }
     end
   end
 
-  context "is closed" do
-    context "when 0%" do
+  context 'is closed' do
+    context 'when 0%' do
       before do
         allow_any_instance_of(Redis).to receive(:get).and_return(0)
         allow_any_instance_of(Redis).to receive(:smembers).and_return(nil)
       end
 
-      it { expect(rcurtain.opened? "feature").to be false }
+      it { expect(rcurtain.opened?('feature')).to be false }
     end
 
-    context "when user does not exists" do
+    context 'when user does not exists' do
       before do
         allow_any_instance_of(Redis).to receive(:get).and_return(0)
-        allow_any_instance_of(Redis).to receive(:smembers).and_return(["MPA-321"])
+        allow_any_instance_of(Redis).to receive(:smembers).and_return(['MPA-321'])
       end
 
-      it { expect(rcurtain.opened?("feature", ['MPA-123'])).to be false }
+      it { expect(rcurtain.opened?('feature', ['MPA-123'])).to be false }
     end
 
-    context "when nothing was found on redis" do
+    context 'when nothing was found on redis' do
       before do
         allow_any_instance_of(Redis).to receive(:get).and_return(nil)
         allow_any_instance_of(Redis).to receive(:smembers).and_return(nil)
       end
 
-      it { expect(rcurtain.opened? "feature_not_found").to be false }
+      it { expect(rcurtain.opened?('feature_not_found')).to be false }
     end
 
-    context "when failed connection" do
+    context 'when failed connection' do
       before do
         allow_any_instance_of(Redis).to receive(:get).and_raise(Redis::CannotConnectError)
         allow_any_instance_of(Redis).to receive(:smembers).and_raise(Redis::CannotConnectError)
       end
 
-      it { expect(rcurtain.opened? "feature").to be false }
+      it { expect(rcurtain.opened?('feature')).to be false }
     end
   end
 
-  context "get users from feature" do
+  context 'get users from feature' do
     before do
       allow_any_instance_of(Redis).to receive(:get).and_return(0)
-      allow_any_instance_of(Redis).to receive(:smembers).and_return(['123', '321'])
+      allow_any_instance_of(Redis).to receive(:smembers).and_return(%w[123 321])
     end
 
-    it { expect(rcurtain.get_users("feature")).to eq ['123', '321'] }
+    it { expect(rcurtain.get_users('feature')).to eq %w[123 321] }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'bundler/setup'
 Bundler.setup
 
 require 'rspec'
-
+require 'pry-byebug'
 require "rcurtain"
 
 RSpec.configure do |config|


### PR DESCRIPTION
The idea of this PR is to supply a demand that emerged from this issue. => https://github.com/wirecardBrasil/jcurtain/issues/3

To resolve the idea of _"get a sample for a given population of user"_ we create new keys for know:
- Percentage which will be extracted from total mass (`feature:feature:users:session:percentage`);
- List of users extrated and calculateds (`feature:feature:users:session:sample`);
- Time to leave in days for delete user extracted list (`feature:feature:users:session:ttl_in_days`);

We used the namespace `session` on keys to give idea which these lists will be removed in any some.

Thanks for @eiguike for support